### PR TITLE
Fix navigation switch-case fall-through

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,8 +63,10 @@ class _MyHomePageState extends State<MyHomePage> {
     switch (selectedIndex) {
       case 0:
         page = GeneratorPage();
+        break;
       case 1:
         page = FavoritesPage();
+        break;
       default:
         throw UnimplementedError("no widget for $selectedIndex");
     }


### PR DESCRIPTION
## Summary
- prevent navigation `switch` from falling through by adding missing `break` statements

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dc01f32b8832ea8f95c24d8ede988